### PR TITLE
`dcargs` -> `tyro`

### DIFF
--- a/obj2mjcf/_cli.py
+++ b/obj2mjcf/_cli.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Sequence
 
-import dcargs
 import mujoco
 import trimesh
+import tyro
 from lxml import etree
 from PIL import Image
 from termcolor import cprint
@@ -541,7 +541,7 @@ def process_obj(filename: Path, args: Args) -> None:
 
 
 def main() -> None:
-    args = dcargs.cli(Args, description=__doc__)
+    args = tyro.cli(Args, description=__doc__)
 
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ core_requirements = [
     "trimesh>=3.15.2",
     "Pillow>=9.1.1",
     "mujoco>=2.2.0",
-    "dcargs>=0.1.2",
+    "tyro>=0.3.22",
     "numpy",
     "termcolor",
     "lxml",


### PR DESCRIPTION
Hey!

I renamed `dcargs`, since the library isn't dataclass-focused anymore. The new name is `tyro`, which doesn't mean anything (types rock?) but is shorter. :slightly_smiling_face: 