### PR TITLE
Make mtl parsing more robust using regex

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
+from itertools import product
 import pathlib
 import subprocess
+
+from obj2mjcf import cli
 
 # Path to the directory containing this file.
 _THIS_DIR = pathlib.Path(__file__).parent.absolute()
@@ -18,3 +21,34 @@ def test_runs_without_error() -> None:
         ]
     )
     assert retcode == 0
+
+
+def test_parse_mtl_line() -> None:
+    file_names = [
+        "A B.mtl",
+        "A_B.mtl",
+        "AbCd.mtl",
+        "a.mtl",
+        "a b.mtl",
+        "a-b.mtl",
+        "a_b.mtl",
+    ]
+    comments = [
+        "",
+        "# comment",
+        " # comment",
+        " # comment #",
+    ]
+    for file_name, comment in product(file_names, comments):
+        line = f"mtllib {file_name}{comment}\n"
+        result = cli.parse_mtl_name(iter([line]))
+        assert result == file_name, result
+
+    for line in (
+            "a",
+            "a # b",
+            "mtllib a.what",
+            "a.mtl",
+    ):
+        result = cli.parse_mtl_name(iter([line]))
+        assert result is None, result


### PR DESCRIPTION
Now supports e.g. whitespaces in filename. Previously, a line like `mtllib Simple Object.mtl\n` would fail.